### PR TITLE
feat: Notion APIレスポンスのファイルベースキャッシュを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,7 @@ bun.lockb
 # Downloaded Notion images
 public/notion-images/
 
+# Notion API cache
+.notion-cache/
+
 .claude/

--- a/src/lib/notion-cache.ts
+++ b/src/lib/notion-cache.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+/** キャッシュディレクトリのパス */
+const CACHE_DIR = join(process.cwd(), '.notion-cache');
+
+/** デフォルトTTL: 1時間 */
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+/** 環境変数 NOTION_CACHE_TTL_MS でTTLを上書き可能（ミリ秒） */
+function getTtlMs(): number {
+  const envTtl = process.env.NOTION_CACHE_TTL_MS;
+  if (envTtl) {
+    const parsed = Number(envTtl);
+    if (parsed > 0) return parsed;
+  }
+  return DEFAULT_TTL_MS;
+}
+
+interface CacheEntry<T> {
+  timestamp: number;
+  data: T;
+}
+
+/** キャッシュキーからファイルパスを生成 */
+function cacheFilePath(key: string): string {
+  const hash = createHash('md5').update(key).digest('hex');
+  return join(CACHE_DIR, `${hash}.json`);
+}
+
+/** キャッシュから読み取り。期限切れまたは存在しない場合は null */
+export function getCached<T>(key: string): T | null {
+  const filePath = cacheFilePath(key);
+  if (!existsSync(filePath)) return null;
+
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const entry: CacheEntry<T> = JSON.parse(raw);
+    const age = Date.now() - entry.timestamp;
+    if (age > getTtlMs()) return null;
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+/** データをキャッシュに保存 */
+export function setCache<T>(key: string, data: T): void {
+  if (!existsSync(CACHE_DIR)) {
+    mkdirSync(CACHE_DIR, { recursive: true });
+  }
+
+  const entry: CacheEntry<T> = {
+    timestamp: Date.now(),
+    data,
+  };
+
+  writeFileSync(cacheFilePath(key), JSON.stringify(entry));
+}
+
+/**
+ * キャッシュ付き非同期関数ラッパー。
+ * キャッシュが有効ならそれを返し、なければ fetcher を実行してキャッシュに保存する。
+ */
+export async function withCache<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  const cached = getCached<T>(key);
+  if (cached !== null) {
+    console.log(`[notion-cache] HIT: ${key}`);
+    return cached;
+  }
+
+  console.log(`[notion-cache] MISS: ${key}`);
+  const data = await fetcher();
+  setCache(key, data);
+  return data;
+}

--- a/src/lib/notion-cache.ts
+++ b/src/lib/notion-cache.ts
@@ -5,8 +5,8 @@ import { join } from 'path';
 /** キャッシュディレクトリのパス */
 const CACHE_DIR = join(process.cwd(), '.notion-cache');
 
-/** デフォルトTTL: 1時間 */
-const DEFAULT_TTL_MS = 60 * 60 * 1000;
+/** デフォルトTTL: 24時間 */
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 /** 環境変数 NOTION_CACHE_TTL_MS でTTLを上書き可能（ミリ秒） */
 function getTtlMs(): number {

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,4 +1,5 @@
 import { Client } from '@notionhq/client';
+import { withCache } from './notion-cache';
 
 // Notion クライアントの初期化
 export const notion = new Client({
@@ -8,81 +9,89 @@ export const notion = new Client({
 // データソースIDの取得
 export const dataSourceId = import.meta.env.NOTION_DATASOURCE_ID;
 
-// Notionデータベースからデータを取得
+// Notionデータベースからデータを取得（キャッシュ付き）
 export async function getNotionData() {
-  try {
-    const response = await notion.dataSources.query({
-      data_source_id: dataSourceId,
-    });
-    return response;
-  } catch (error) {
-    console.error('Notion API Error:', error);
-    throw error;
-  }
-}
-
-// 個別ページの詳細を取得
-export async function getNotionPage(pageId: string) {
-  try {
-    const page = await notion.pages.retrieve({ page_id: pageId });
-    return page;
-  } catch (error) {
-    console.error('Notion Page Retrieve Error:', error);
-    throw error;
-  }
-}
-
-// ページのブロック（コンテンツ）を取得
-export async function getNotionBlocks(pageId: string) {
-  try {
-    const blocks = await notion.blocks.children.list({
-      block_id: pageId,
-    });
-    return blocks;
-  } catch (error) {
-    console.error('Notion Blocks List Error:', error);
-    throw error;
-  }
-}
-
-// ブロックを再帰的に取得（子ブロックを含む・ページネーション対応）
-export async function getNotionBlocksRecursive(blockId: string): Promise<any[]> {
-  try {
-    const results: any[] = [];
-    let startCursor: string | undefined;
-
-    do {
-      const response: any = await notion.blocks.children.list({
-        block_id: blockId,
-        page_size: 100,
-        ...(startCursor ? { start_cursor: startCursor } : {}),
+  return withCache('notionData', async () => {
+    try {
+      const response = await notion.dataSources.query({
+        data_source_id: dataSourceId,
       });
-      results.push(...(response.results ?? []));
-      startCursor = response.has_more ? response.next_cursor : undefined;
-    } while (startCursor);
+      return response;
+    } catch (error) {
+      console.error('Notion API Error:', error);
+      throw error;
+    }
+  });
+}
 
-    // 各ブロックに対して、子ブロックがある場合は再帰的に取得
-    const blocksWithChildren = await Promise.all(
-      results.map(async (block: any) => {
-        if (block.has_children) {
-          const children = await getNotionBlocksRecursive(block.id);
-          return { ...block, children };
-        }
-        return block;
-      }),
-    );
+// 個別ページの詳細を取得（キャッシュ付き）
+export async function getNotionPage(pageId: string) {
+  return withCache(`notionPage:${pageId}`, async () => {
+    try {
+      const page = await notion.pages.retrieve({ page_id: pageId });
+      return page;
+    } catch (error) {
+      console.error('Notion Page Retrieve Error:', error);
+      throw error;
+    }
+  });
+}
 
-    return blocksWithChildren;
-  } catch (error) {
-    console.error('Notion Blocks Recursive Error:', error);
-    throw error;
-  }
+// ページのブロック（コンテンツ）を取得（キャッシュ付き）
+export async function getNotionBlocks(pageId: string) {
+  return withCache(`notionBlocks:${pageId}`, async () => {
+    try {
+      const blocks = await notion.blocks.children.list({
+        block_id: pageId,
+      });
+      return blocks;
+    } catch (error) {
+      console.error('Notion Blocks List Error:', error);
+      throw error;
+    }
+  });
+}
+
+// ブロックを再帰的に取得（子ブロックを含む・ページネーション対応・キャッシュ付き）
+export async function getNotionBlocksRecursive(blockId: string): Promise<any[]> {
+  return withCache(`notionBlocksRecursive:${blockId}`, async () => {
+    try {
+      const results: any[] = [];
+      let startCursor: string | undefined;
+
+      do {
+        const response: any = await notion.blocks.children.list({
+          block_id: blockId,
+          page_size: 100,
+          ...(startCursor ? { start_cursor: startCursor } : {}),
+        });
+        results.push(...(response.results ?? []));
+        startCursor = response.has_more ? response.next_cursor : undefined;
+      } while (startCursor);
+
+      // 各ブロックに対して、子ブロックがある場合は再帰的に取得
+      const blocksWithChildren = await Promise.all(
+        results.map(async (block: any) => {
+          if (block.has_children) {
+            const children = await getNotionBlocksRecursive(block.id);
+            return { ...block, children };
+          }
+          return block;
+        }),
+      );
+
+      return blocksWithChildren;
+    } catch (error) {
+      console.error('Notion Blocks Recursive Error:', error);
+      throw error;
+    }
+  });
 }
 
 // カスタムIDからページを検索する関数
 export async function findPageByCustomId(customId: string) {
   try {
-    // データソースから全データを取得
+    // データソースから全データを取得（getNotionData内でキャッシュされる）
     const response = await getNotionData();
 
     // カスタムIDがマッチするページを検索


### PR DESCRIPTION
ビルドのたびにNotion APIを呼び出していた問題を解消。
getNotionData / getNotionPage / getNotionBlocksRecursive の結果を .notion-cache/ にJSONファイルとして保存し、TTL（デフォルト1時間）以内
であれば再利用する。環境変数 NOTION_CACHE_TTL_MS で調整可能。

https://claude.ai/code/session_01F6jD6sccDZ2P6YefLZ9orQ